### PR TITLE
New getDeltaRefGibbs and getDeltaRefEntropy methods added to Kinetics.h and InterfaceKinetics.h and .cpp

### DIFF
--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -48,9 +48,6 @@ public:
 
     // Utility methods to get reaction Deltas
     virtual void getDeltaRefGibbs(doublereal* deltaG);
-    virtual void getDeltaRefEnthalpy(doublereal* deltaH){
-        throw NotImplementedError("GasKinetics::getDeltaRefEnthalpy");
-    }
     virtual void getDeltaRefEntropy(doublereal* deltaS);
 
     //! @}

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -46,6 +46,13 @@ public:
     virtual void getEquilibriumConstants(doublereal* kc);
     virtual void getFwdRateConstants(doublereal* kfwd);
 
+    // Utility methods to get reaction Deltas
+    virtual void getDeltaRefGibbs(doublereal* deltaG);
+    virtual void getDeltaRefEnthalpy(doublereal* deltaH){
+        throw NotImplementedError("GasKinetics::getDeltaRefEnthalpy");
+    }
+    virtual void getDeltaRefEntropy(doublereal* deltaS);
+
     //! @}
     //! @name Reaction Mechanism Setup Routines
     //! @{

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -107,7 +107,9 @@ public:
     virtual void getDeltaSSEntropy(doublereal* deltaS);
 
     virtual void getDeltaRefGibbs(doublereal* deltaG);
-    virtual void getDeltaRefEnthalpy(doublereal* deltaH);
+    virtual void getDeltaRefEnthalpy(doublereal* deltaH) {
+        throw NotImplementedError("InterfaceKinetics::getDeltaRefEnthalpy");
+    }
     virtual void getDeltaRefEntropy(doublereal* deltaS);
 
     //! @}

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -107,6 +107,7 @@ public:
     virtual void getDeltaSSEntropy(doublereal* deltaS);
 
     virtual void getDeltaRefGibbs(doublereal* deltaG);
+	virtual void getDeltaRefEnthalpy(doublereal* deltaH);
     virtual void getDeltaRefEntropy(doublereal* deltaS);
 
     //! @}

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -106,6 +106,9 @@ public:
     virtual void getDeltaSSEnthalpy(doublereal* deltaH);
     virtual void getDeltaSSEntropy(doublereal* deltaS);
 
+    virtual void getDeltaRefGibbs(doublereal* deltaG);
+    virtual void getDeltaRefEntropy(doublereal* deltaS);
+
     //! @}
     //! @name Reaction Mechanism Informational Query Routines
     //! @{

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -107,7 +107,7 @@ public:
     virtual void getDeltaSSEntropy(doublereal* deltaS);
 
     virtual void getDeltaRefGibbs(doublereal* deltaG);
-	virtual void getDeltaRefEnthalpy(doublereal* deltaH);
+    virtual void getDeltaRefEnthalpy(doublereal* deltaH);
     virtual void getDeltaRefEntropy(doublereal* deltaS);
 
     //! @}

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -107,9 +107,6 @@ public:
     virtual void getDeltaSSEntropy(doublereal* deltaS);
 
     virtual void getDeltaRefGibbs(doublereal* deltaG);
-    virtual void getDeltaRefEnthalpy(doublereal* deltaH) {
-        throw NotImplementedError("InterfaceKinetics::getDeltaRefEnthalpy");
-    }
     virtual void getDeltaRefEntropy(doublereal* deltaS);
 
     //! @}

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -514,12 +514,46 @@ public:
         throw NotImplementedError("Kinetics::getDeltaSSEntropy");
     }
 
+    /**
+     * Return the vector of values for the change in the standard state
+     * entropies for each reaction at reference pressure of 1 bar. These values
+	 * don't depend upon the concentration of the solution.
+     *
+     *  units = J kmol-1 Kelvin-1
+     *
+     * @param deltaS  Output vector of ss deltaS's for reactions Length:
+     *     nReactions().
+     */
     virtual void getDeltaRefEntropy(doublereal* deltaS) {
         throw NotImplementedError("Kinetics::getDeltaRefEntropy");
     }
 
+    /**
+     * Return the vector of values for the reaction standard state Gibbs free
+     * energy change at reference pressure of 1 bar. These values don't 
+     * depend upon the concentration of the solution.
+     *
+     *  units = J kmol-1
+     *
+     * @param deltaG  Output vector of ss deltaG's for reactions Length:
+     *     nReactions().
+     */
     virtual void getDeltaRefGibbs(doublereal* deltaG) {
         throw NotImplementedError("Kinetics::getDeltaRefGibbs");
+    }
+
+    /**
+     * Return the vector of values for the change in the standard state
+     * enthalpies of each reaction at reference pressure of 1 bar. These values don't 
+     * depend upon the concentration of the solution.
+     *
+     *  units = J kmol-1
+     *
+     * @param deltaH  Output vector of ss deltaH's for reactions Length:
+     *     nReactions().
+     */
+    virtual void getDeltaRefEnthalpy(doublereal* deltaH) {
+        throw NotImplementedError("Kinetics::getDeltaRefEnthalpy");
     }
 
     //! @}

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -514,6 +514,14 @@ public:
         throw NotImplementedError("Kinetics::getDeltaSSEntropy");
     }
 
+    virtual void getDeltaRefEntropy(doublereal* deltaS) {
+        throw NotImplementedError("Kinetics::getDeltaRefEntropy");
+    }
+
+    virtual void getDeltaRefGibbs(doublereal* deltaG) {
+        throw NotImplementedError("Kinetics::getDeltaRefGibbs");
+    }
+
     //! @}
     //! @name Species Production Rates
     //! @{

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -222,6 +222,41 @@ void GasKinetics::getFwdRateConstants(doublereal* kfwd)
     }
 }
 
+void GasKinetics::getDeltaRefGibbs(doublereal* deltaGSS)
+{
+    // Get the reference state chemical potentials of the species. This is the
+    // array of chemical potentials at unit activity We define these here as the
+    // chemical potentials of the pure species at the temperature and reference 
+    // pressure of 1 bar of the solution.
+    for (size_t n = 0; n < nPhases(); n++) {
+        thermo(n).getGibbs_RT_ref(m_grt.data() + m_start[n]);
+    }
+
+    for (size_t k = 0; k < m_kk; k++) {
+        m_grt[k] *= thermo(reactionPhaseIndex()).RT();
+    }
+
+    // Use the stoichiometric manager to find deltaG for each reaction.
+    //getReactionDelta(m_mu0.data(), deltaGSS);
+    getReactionDelta(m_grt.data(), deltaGSS);
+}
+
+void GasKinetics::getDeltaRefEntropy(doublereal* deltaS)
+{
+    // Get the reference state entropy of the species. We define these here as
+    // the entropies of the pure species at the temperature and at reference 
+    // pressure of 1 bar of the solution.
+    for (size_t n = 0; n < nPhases(); n++) {
+        thermo(n).getEntropy_R_ref(m_grt.data() + m_start[n]);
+    }
+    for (size_t k = 0; k < m_kk; k++) {
+        m_grt[k] *= GasConstant;
+    }
+
+    // Use the stoichiometric manager to find deltaS for each reaction.
+    getReactionDelta(m_grt.data(), deltaS);
+}
+
 bool GasKinetics::addReaction(shared_ptr<Reaction> r)
 {
     // operations common to all reaction types

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -562,8 +562,8 @@ void InterfaceKinetics::getDeltaSSEntropy(doublereal* deltaS)
 void InterfaceKinetics::getDeltaRefEntropy(doublereal* deltaS)
 {
     // Get the standard state entropy of the species. We define these here as
-    // the entropies of the pure species at the temperature and pressure of the
-    // solution.
+    // the entropies of the pure species at the temperature and at reference 
+    // pressure of the solution.
     for (size_t n = 0; n < nPhases(); n++) {
         thermo(n).getEntropy_R_ref(m_grt.data() + m_start[n]);
     }

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -499,10 +499,31 @@ void InterfaceKinetics::getDeltaSSGibbs(doublereal* deltaGSS)
     // of the solution.
     for (size_t n = 0; n < nPhases(); n++) {
         thermo(n).getStandardChemPotentials(m_mu0.data() + m_start[n]);
+        //thermo(n).getGibbs_RT_ref(m_grt.data() + m_start[n]);
     }
 
     // Use the stoichiometric manager to find deltaG for each reaction.
+    //getReactionDelta(m_mu0.data(), deltaGSS);
     getReactionDelta(m_mu0.data(), deltaGSS);
+}
+
+void InterfaceKinetics::getDeltaRefGibbs(doublereal * deltaGSS)
+{
+    // Get the standard state chemical potentials of the species. This is the
+    // array of chemical potentials at unit activity We define these here as the
+    // chemical potentials of the pure species at the temperature and reference 
+    // pressure of the solution.
+    for (size_t n = 0; n < nPhases(); n++) {
+        thermo(n).getGibbs_RT_ref(m_grt.data() + m_start[n]);
+    }
+
+    for (size_t k = 0; k < m_kk; k++) {
+        m_grt[k] *= thermo(reactionPhaseIndex()).RT();
+    }
+
+    // Use the stoichiometric manager to find deltaG for each reaction.
+    //getReactionDelta(m_mu0.data(), deltaGSS);
+    getReactionDelta(m_grt.data(), deltaGSS);
 }
 
 void InterfaceKinetics::getDeltaSSEnthalpy(doublereal* deltaH)
@@ -529,6 +550,22 @@ void InterfaceKinetics::getDeltaSSEntropy(doublereal* deltaS)
     // solution.
     for (size_t n = 0; n < nPhases(); n++) {
         thermo(n).getEntropy_R(m_grt.data() + m_start[n]);
+    }
+    for (size_t k = 0; k < m_kk; k++) {
+        m_grt[k] *= GasConstant;
+    }
+
+    // Use the stoichiometric manager to find deltaS for each reaction.
+    getReactionDelta(m_grt.data(), deltaS);
+}
+
+void InterfaceKinetics::getDeltaRefEntropy(doublereal* deltaS)
+{
+    // Get the standard state entropy of the species. We define these here as
+    // the entropies of the pure species at the temperature and pressure of the
+    // solution.
+    for (size_t n = 0; n < nPhases(); n++) {
+        thermo(n).getEntropy_R_ref(m_grt.data() + m_start[n]);
     }
     for (size_t k = 0; k < m_kk; k++) {
         m_grt[k] *= GasConstant;

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -499,20 +499,18 @@ void InterfaceKinetics::getDeltaSSGibbs(doublereal* deltaGSS)
     // of the solution.
     for (size_t n = 0; n < nPhases(); n++) {
         thermo(n).getStandardChemPotentials(m_mu0.data() + m_start[n]);
-        //thermo(n).getGibbs_RT_ref(m_grt.data() + m_start[n]);
     }
 
     // Use the stoichiometric manager to find deltaG for each reaction.
-    //getReactionDelta(m_mu0.data(), deltaGSS);
     getReactionDelta(m_mu0.data(), deltaGSS);
 }
 
 void InterfaceKinetics::getDeltaRefGibbs(doublereal * deltaGSS)
 {
-    // Get the standard state chemical potentials of the species. This is the
+    // Get the reference state chemical potentials of the species. This is the
     // array of chemical potentials at unit activity We define these here as the
     // chemical potentials of the pure species at the temperature and reference 
-    // pressure of the solution.
+    // pressure of 1 bar of the solution.
     for (size_t n = 0; n < nPhases(); n++) {
         thermo(n).getGibbs_RT_ref(m_grt.data() + m_start[n]);
     }
@@ -561,9 +559,9 @@ void InterfaceKinetics::getDeltaSSEntropy(doublereal* deltaS)
 
 void InterfaceKinetics::getDeltaRefEntropy(doublereal* deltaS)
 {
-    // Get the standard state entropy of the species. We define these here as
+    // Get the reference state entropy of the species. We define these here as
     // the entropies of the pure species at the temperature and at reference 
-    // pressure of the solution.
+    // pressure of 1 bar of the solution.
     for (size_t n = 0; n < nPhases(); n++) {
         thermo(n).getEntropy_R_ref(m_grt.data() + m_start[n]);
     }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [ ] There is a clear use-case for this code change
- [ ] The commit message has a short title & references relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes VlachosGroup/openmkm#42, VlachosGroup/openmkm#50 

**Changes proposed in this pull request**

- This PR add new methods `getDeltaRefGibbs` and `getDeltaRefEntropy`  `getDeltaRefEnthalpy` to the header files Kinetics.h and InterfaceKinetics.h and the implements them in the Kinetics.cpp. The purpose of this method is to estimate reaction Delta entropy and Delta gibbs free energy at the standard stated of each species and also at the reference pressure of 1 bar. These routines are subsequently used in OpenMKM to print the reaction Deltas (S and G) at 1 bar so that it is consistent with the output of the CHEMKIN software package (https://doi.org/10.2172/481906). The reaction deltas is an array with length equal to the number of reactions. 
- (New) Code and comment cleanup corresponding to the above addition is also performed here based on the review from PR #1 
- Resolves several issues i.e. VlachosGroup/openmkm#42, VlachosGroup/openmkm#50 