### PR TITLE
YAML Thermo Bug-Fix: BEP.cpp and LateralInteraction.cpp

### DIFF
--- a/src/kinetics/BEP.cpp
+++ b/src/kinetics/BEP.cpp
@@ -268,7 +268,7 @@ shared_ptr<BEP> newBEP(const AnyMap& bep_node, const AnyMap& rootNode)
     string id = bep_node["id"].asString();
     double slope = bep_node["slope"].asDouble();
     auto units = bep_node.units();
-    double intercept = units.convertActivationEnergy(bep_node["intercept"], "K");
+    double intercept = units.convertActivationEnergy(bep_node["intercept"], "J/kmol");
     string dir = bep_node["direction"].asString();
 
     bool isCleave;

--- a/src/thermo/LateralInteraction.cpp
+++ b/src/thermo/LateralInteraction.cpp
@@ -138,8 +138,7 @@ shared_ptr<LateralInteraction> newLateralInteraction(const AnyMap& intrxnNode)
     //auto strengths = intrxnNode.convertVector("strength", "K", 
     vector<double> slopes;
     for (auto& strength : strengths) {
-        slopes.push_back(units.convertActivationEnergy(strength, "K"));
-        
+        slopes.push_back(units.convertActivationEnergy(strength, "J/kmol"));
     }
     auto covs = intrxnNode["coverage-threshold"].asVector<double>();
     


### PR DESCRIPTION
Updating the BEP and Lateral Interaction code to fix a bug with unit conversion for data read from a YAML thermo specification file.

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Changed the assumed default units of lateral interaction strength (energy) and BEP slope (energy) parameter read from the YAML thermodynamic specification input file. 